### PR TITLE
Add essential Vite setup files

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Restaurant Finder Morocco</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32px" height="32px" viewBox="0 0 32 32" version="1.1">
+<g id="surface1">
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(25.490196%,72.156863%,51.372549%);fill-opacity:1;" d="M 16 2 L 3 7 L 5 24 L 16 30 L 27 24 L 29 7 Z M 16 2 "/>
+</g>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,9 @@
+function App() {
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <h1>Hello World</h1>
+    </div>
+  )
+}
+
+export default App

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)


### PR DESCRIPTION
This PR adds the essential Vite setup files that were missing:

1. `index.html` - The entry point HTML file
2. `src/main.tsx` - The main React entry point
3. `src/App.tsx` - A basic App component
4. `src/index.css` - Base CSS file with Tailwind imports
5. `public/vite.svg` - Favicon

These files are required for Vite to properly serve the application.

To test:
1. Pull this branch
2. Run `npm install`
3. Run `npm run dev`
4. Open http://localhost:5173

You should now see a "Hello World" message instead of a 404 error.